### PR TITLE
Make tox.ini as generic as possible

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,7 @@
 # If you use conda, you may also want to install tox-conda
 # then run `tox` or `tox -- {pytest args}`
 # run in parallel using `tox -p`
-[tox]
-envlist = py39
-
 [testenv]
-deps = pytest
 usedevelop = true
-
-[testenv:py{39,310,311,312,313}]
 extras = test
 commands = pytest {posargs}


### PR DESCRIPTION
This will allow to run tests for Python versions that are not officially supported.  For example, if you run `tox -e py314` without this change then it will do nothing.  This change also makes the `tox.ini` generic enough so it will be not needed to update it when the new Python version gets supported by `uc-micro-py` (or support for old Python version is dropped).